### PR TITLE
Add BLIS support via blis-src

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rust:
 
 env:
   - FEATURE=accelerate
+  - FEATURE=blis
   - FEATURE=intel-mkl
   - FEATURE=netlib
   - FEATURE=openblas

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blas-src"
-version = "0.6.1"
+version = "0.6.2"
 license = "Apache-2.0/MIT"
 authors = [
     "Ivan Ukhov <ivan.ukhov@gmail.com>",
@@ -17,12 +17,17 @@ keywords = ["linear-algebra"]
 
 [features]
 accelerate = ["accelerate-src"]
+blis = ["blis-src"]
 intel-mkl = ["intel-mkl-src"]
 netlib = ["netlib-src"]
 openblas = ["openblas-src"]
 
 [dependencies.accelerate-src]
 version = "0.3"
+optional = true
+
+[dependencies.blis-src]
+version = "0.2"
 optional = true
 
 [dependencies.intel-mkl-src]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The usage of the package is explained [here][usage].
 The following implementations are available:
 
 * `accelerate`, which is the one in the [Accelerate] framework (macOS only),
+* `blis`, which is the one in [BLIS].
 * `intel-mkl`, which is the one in [Intel MKL],
 * `netlib`, which is the reference one by [Netlib], and
 * `openblas`, which is the one in [OpenBLAS].
@@ -18,6 +19,7 @@ An implementation can be chosen as follows:
 ```toml
 [dependencies]
 blas-src = { version = "0.6", features = ["accelerate"] }
+blas-src = { version = "0.6.2", features = ["blis"] }
 blas-src = { version = "0.6", features = ["intel-mkl"] }
 blas-src = { version = "0.6", features = ["netlib"] }
 blas-src = { version = "0.6", features = ["openblas"] }
@@ -31,6 +33,7 @@ will be licensed according to the terms given in [LICENSE.md](LICENSE.md).
 
 [accelerate]: https://developer.apple.com/reference/accelerate
 [blas]: https://en.wikipedia.org/wiki/BLAS
+[blis]: https://github.com/flame/blis
 [intel mkl]: https://software.intel.com/en-us/mkl
 [netlib]: http://www.netlib.org/
 [openblas]: http://www.openblas.net/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! The following implementations are available:
 //!
 //! * `accelerate`, which is the one in the [Accelerate] framework (macOS only),
+//! * `blis`, which is the one in [BLIS].
 //! * `intel-mkl`, which is the one in [Intel MKL],
 //! * `netlib`, which is the reference one by [Netlib], and
 //! * `openblas`, which is the one in [OpenBLAS].
@@ -16,6 +17,7 @@
 //! ```toml
 //! [dependencies]
 //! blas-src = { version = "0.6", features = ["accelerate"] }
+//! blas-src = { version = "0.6.2", features = ["blis"] }
 //! blas-src = { version = "0.6", features = ["intel-mkl"] }
 //! blas-src = { version = "0.6", features = ["netlib"] }
 //! blas-src = { version = "0.6", features = ["openblas"] }
@@ -23,6 +25,7 @@
 //!
 //! [accelerate]: https://developer.apple.com/reference/accelerate
 //! [blas]: https://en.wikipedia.org/wiki/BLAS
+//! [blis]: https://github.com/flame/blis
 //! [intel mkl]: https://software.intel.com/en-us/mkl
 //! [netlib]: http://www.netlib.org/
 //! [openblas]: http://www.openblas.net/
@@ -32,6 +35,9 @@
 
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src as raw;
+
+#[cfg(feature = "blis")]
+extern crate blis_src as raw;
 
 #[cfg(feature = "intel-mkl")]
 extern crate intel_mkl_src as raw;


### PR DESCRIPTION
BLIS significantly outperforms OpenBLAS in many scenarios, especially on Zen/Zen2 and some ARM. https://github.com/flame/blis/blob/master/docs/Performance.md

This is based on newly-updated [blis-src](https://crates.io/crates/blis-src). BLIS also builds faster than OpenBLAS.