### PR TITLE
Bump version in README and lib file to 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ An implementation can be chosen as follows:
 
 ```toml
 [dependencies]
-blas-src = { version = "0.9", features = ["accelerate"] }
-blas-src = { version = "0.9", features = ["blis"] }
-blas-src = { version = "0.9", features = ["intel-mkl"] }
-blas-src = { version = "0.9", features = ["netlib"] }
-blas-src = { version = "0.9", features = ["openblas"] }
-blas-src = { version = "0.9", features = ["r"] }
+blas-src = { version = "0.10", features = ["accelerate"] }
+blas-src = { version = "0.10", features = ["blis"] }
+blas-src = { version = "0.10", features = ["intel-mkl"] }
+blas-src = { version = "0.10", features = ["netlib"] }
+blas-src = { version = "0.10", features = ["openblas"] }
+blas-src = { version = "0.10", features = ["r"] }
 ```
 
 ## Contribution

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,12 @@
 //!
 //! ```toml
 //! [dependencies]
-//! blas-src = { version = "0.9", features = ["accelerate"] }
-//! blas-src = { version = "0.9", features = ["blis"] }
-//! blas-src = { version = "0.9", features = ["intel-mkl"] }
-//! blas-src = { version = "0.9", features = ["netlib"] }
-//! blas-src = { version = "0.9", features = ["openblas"] }
-//! blas-src = { version = "0.9", features = ["r"] }
+//! blas-src = { version = "0.10", features = ["accelerate"] }
+//! blas-src = { version = "0.10", features = ["blis"] }
+//! blas-src = { version = "0.10", features = ["intel-mkl"] }
+//! blas-src = { version = "0.10", features = ["netlib"] }
+//! blas-src = { version = "0.10", features = ["openblas"] }
+//! blas-src = { version = "0.10", features = ["r"] }
 //! ```
 //!
 //! [architecture]: https://blas-lapack-rs.github.io/architecture


### PR DESCRIPTION
Hi! I was using the crate and realized the version should be bumped in the documentation. I compared it with #19  to ensure I got all the instances.
Thank you!