### PR TITLE
Feature/update edition2024 and clear error on multiblas build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blas-src"
 version = "0.11.1"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 authors = [
     "Augusto Borges <borges.augustoar@gmail.com>",
@@ -45,7 +45,7 @@ version = "0.8"
 optional = true
 
 [dependencies.netlib-src]
-version = "0.9"
+version = "0.8"
 optional = true
 
 [dependencies.openblas-src]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ version = "0.8"
 optional = true
 
 [dependencies.netlib-src]
-version = "0.8"
+version = "0.9"
 optional = true
 
 [dependencies.openblas-src]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let features = ["accelerate", "blis", "intel-mkl", "netlib", "openblas", "r"];
+    let mut count = 0;
+    for feature in &features {
+        if std::env::var(format!(
+            "CARGO_FEATURE_{}",
+            feature.to_uppercase().replace('-', "_")
+        ))
+        .is_ok()
+        {
+            count += 1;
+        }
+    }
+
+    if count > 1 {
+        panic!("Only one BLAS implementation feature may be enabled at a time.");
+    }
+}


### PR DESCRIPTION
Small updates to make the error more clear by checking that only one BLAS is enabled at a time

Upstream may for example innocently `cargo build --all-features` and now it is more clear why they should not.